### PR TITLE
feat: Implement Pomodoro Plugin with Core Logic, UI, and Daily Note Logging

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -123,7 +123,9 @@ export default class PomodoroPlugin extends Plugin {
                 // The PomodoroView will update itself via its registered interval
             },
             () => {
-                new Notice(this.timer.getIsPomodoro() ? 'Pomodoro Complete!' : 'Break Complete!');
+                const sessionType = this.timer.getIsPomodoro() ? 'Pomodoro' : 'Break';
+                new Notice(`${sessionType} Complete!`);
+                this.handleSessionEnd(sessionType);
                 this.logSession();
                 if (this.settings.autoStartNextSession) {
                     this.startTimer();
@@ -173,6 +175,21 @@ export default class PomodoroPlugin extends Plugin {
         } else {
             const newDailyNote = await createDailyNote(now);
             await this.app.vault.append(newDailyNote, `\n${logEntry}`);
+        }
+    }
+
+    handleSessionEnd(sessionType: string) {
+        if (this.settings.enableNotifications) {
+            new Notification('Obsidian Pomodoro', {
+                body: `${sessionType} session complete!`,
+            });
+        }
+        if (this.settings.enableSound) {
+            // You would typically play a sound here.
+            // In a browser environment, this would be an Audio object.
+            // For Obsidian, you might need to use a different approach or rely on OS notification sounds.
+            // For simplicity, we'll just log for now.
+            console.log('Playing session end sound.');
         }
     }
 }


### PR DESCRIPTION

This PR introduces the initial implementation of the Obsidian Pomodoro plugin, fulfilling the core requirements outlined in the development plan.

**Key Features Implemented:**

*   **Core Logic:** Implemented `PomodoroTimer` class for managing timer states (start, pause, reset, skip) and cycle progression (pomodoro, short break, long break).
*   **Status Bar UI:** Displays the current timer status and remaining time in the Obsidian status bar (e.g., `🍅 24:59`).
*   **Command Palette Integration:** Added commands to start, pause, reset, and skip the pomodoro sessions via the command palette.
*   **Graphical UI (View):** Registered a new view (`PomodoroView`) accessible via a ribbon icon. This view displays a visual timer and control buttons (play/pause, reset, skip).
*   **Settings Tab:** Implemented a settings tab allowing users to configure:
    *   Pomodoro duration
    *   Short break duration
    *   Long break duration
    *   Cycles before long break
    *   Auto-start next session
    *   Enable/disable notifications
    *   Enable/disable sound
*   **Daily Note Logging:** Integrated with the Daily Notes API to automatically log completed pomodoro/break sessions to the current day's daily note, creating the note if it doesn't exist. The log format includes session type, duration, and the active note at the time of completion.
*   **OS Native Notifications:** Added support for OS native desktop notifications when a session ends.
*   **Styling:** Added basic CSS to style the Pomodoro view.

**Next Steps:**

*   Further refine the UI/UX, especially the visual ring timer.
*   Implement sound options (currently a placeholder).
*   Add more robust error handling and user feedback.
*   Consider additional features like customizable session names, history view, etc.

This PR lays the foundation for a fully functional Pomodoro plugin within Obsidian.
